### PR TITLE
Correct 'Dynamic Library Install Name Base'.

### DIFF
--- a/EvernoteSDK.xcodeproj/project.pbxproj
+++ b/EvernoteSDK.xcodeproj/project.pbxproj
@@ -1834,6 +1834,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",
@@ -1863,6 +1864,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",


### PR DESCRIPTION
Change 'Dynamic Library Install Name Base' (i.e., DYLIB_INSTALL_NAME_BASE) from '/Library/Frameworks' to '@rpath'. 

Otherwise the macOS App used can't correctly run with error of ''dyld: Library not loaded: /Library/Frameworks/EvernoteSDK-Mac.framework/Versions/A/EvernoteSDK-Mac"